### PR TITLE
Add Django Rest Framework and Implement User Registration and Login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Ignore virtual environment
+.venv
 /venv/
 /story_server/venv
+
+# Ignore local .env
+.env
 
 # Ignore Python cache files
 *.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,13 @@ environ==1.0
 psycopg2==2.9.10
 sqlparse==0.5.3
 typing_extensions==4.12.2
+asgiref==3.8.1
+dj-database-url==2.3.0
+Django==5.1.5
+django-cors-headers==4.6.0
+django-environ==0.12.0
+djangorestframework==3.16.0
+environ==1.0
+psycopg2==2.9.10
+sqlparse==0.5.3
+typing_extensions==4.12.2

--- a/stories/models.py
+++ b/stories/models.py
@@ -2,9 +2,7 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from datetime import date
-
 import uuid
-
 
 class Story(models.Model):
     title = models.CharField(max_length=255)
@@ -15,12 +13,12 @@ class Story(models.Model):
         default=uuid.uuid4,  # Automatically generate a new UUID
         editable=False       # Prevent manual editing of the UUID
     )
-    
-    def __str__(self):        
+
+    def __str__(self):
         return self.title
 
 class StoryEval(models.Model):
-    
+
     class Status(models.TextChoices):
         UNREAD = 'UR', _('Unread')
         IN_PROGRESS = 'IP', _('In Progress')
@@ -44,9 +42,10 @@ class StoryEval(models.Model):
     )
     class Meta:
         unique_together = ("story", "reader")  # Prevents duplicate evaluations from the same reader
-        
+
     def __str__(self):
         return f"{self.reader.user.username} -> {self.story.title} ({self.rating})"
+
 class Reader(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="reader")
     id = models.UUIDField(
@@ -54,9 +53,6 @@ class Reader(models.Model):
         default=uuid.uuid4,  # Automatically generate a new UUID
         editable=False       # Prevent manual editing of the UUID
     )
-    
+
     def __str__(self):
         return f"Reader: {self.user.username}"
-
-
-    

--- a/stories/serializers.py
+++ b/stories/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from stories.models import Story
+from stories.models import Story, Reader
 from django.contrib.auth import get_user_model
 
 class StorySerializer(serializers.ModelSerializer):
@@ -8,6 +8,9 @@ class StorySerializer(serializers.ModelSerializer):
         fields = ['id', 'title', 'author', 'link']
 
 User = get_user_model()
+
+def create_reader(user):
+    Reader.objects.create(user=user)
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -19,4 +22,8 @@ class UserSerializer(serializers.ModelSerializer):
         user = User(**validated_data)
         user.set_password(validated_data['password'])
         user.save()
+
+        # Create associated Reader object when a new user signs up
+        create_reader(user)
+
         return user

--- a/stories/serializers.py
+++ b/stories/serializers.py
@@ -1,7 +1,22 @@
 from rest_framework import serializers
 from stories.models import Story
+from django.contrib.auth import get_user_model
 
 class StorySerializer(serializers.ModelSerializer):
     class Meta:
         model = Story
         fields = ['id', 'title', 'author', 'link']
+
+User = get_user_model()
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('username', 'email', 'password')
+        extra_kwargs = {'password': {'write_only': True}}
+
+    def create(self, validated_data):
+        user = User(**validated_data)
+        user.set_password(validated_data['password'])
+        user.save()
+        return user

--- a/stories/serializers.py
+++ b/stories/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from stories.models import Story
+
+class StorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Story
+        fields = ['id', 'title', 'author', 'link']

--- a/stories/urls.py
+++ b/stories/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('stories/<str:id>', views.detail, name='detail'),
     path('story-evals/<str:username>/', views.reader_story_evals, name='story-evals'),
     path('signup/', views.RegisterView.as_view(), name='signup'),
-    path('signin/', views.LoginView.as_view(), name='signin')
+    path('signin/', views.LoginView.as_view(), name='signin'),
+    path('logout/', views.LogoutView.as_view(), name='logout')
 ]

--- a/stories/urls.py
+++ b/stories/urls.py
@@ -1,9 +1,10 @@
-from django.urls import path
-
+from django.urls import path, include
 from . import views
 
 urlpatterns = [
-    path("", views.stories_list, name="stories_list"),
-    path('<str:id>', views.detail, name='detail'),
+    path('stories/', views.stories_list, name="stories_list"),
+    path('stories/<str:id>', views.detail, name='detail'),
     path('story-evals/<str:username>/', views.reader_story_evals, name='story-evals'),
+    path('signup/', views.RegisterView.as_view(), name='signup'),
+    path('signin/', views.LoginView.as_view(), name='signin')
 ]

--- a/stories/urls.py
+++ b/stories/urls.py
@@ -3,8 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("", views.all_stories, name="all_stories"),
+    path("", views.stories_list, name="stories_list"),
     path('<str:id>', views.detail, name='detail'),
     path('story-evals/<str:username>/', views.reader_story_evals, name='story-evals'),
-
 ]

--- a/stories/views.py
+++ b/stories/views.py
@@ -2,7 +2,8 @@ from django.core.serializers import serialize
 from django.http import HttpResponse, JsonResponse
 from rest_framework.parsers import JSONParser
 from rest_framework import generics
-from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
@@ -36,6 +37,18 @@ class LoginView(ObtainAuthToken):
             token, created = Token.objects.get_or_create(user=user)
             return Response({'username': user.username, 'token': token.key})
         return Response({'error': 'Invalid Credentials'}, status=400)
+
+class LogoutView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        try:
+            request.user.auth_token.delete()
+            return Response({"message": "Successfully logged out."}, status=200)
+        except Exception as e:
+            return Response({"error": str(e)}, status=400)
+
+
 
 def detail(request, id):
   story = Story.objects.get(id=id)

--- a/stories/views.py
+++ b/stories/views.py
@@ -1,21 +1,26 @@
 from django.core.serializers import serialize
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
+from rest_framework.parsers import JSONParser
 from django.shortcuts import get_object_or_404
 
 from .models import Story
 from .models import StoryEval, Reader
+from .serializers import StorySerializer
 from django.contrib.auth.models import User
-
-# Create your views here.
 
 def detail(request, id):
   story = Story.objects.get(id=id)
   story_json = serialize('json', [story])
   return JsonResponse(story_json, safe=False)
 
-def all_stories(request):
-  stories = Story.objects.values('id', 'title', 'author')
-  return JsonResponse(list(stories), safe=False)
+def stories_list(request):
+    """
+    List all stories
+    """
+    if request.method == 'GET':
+        stories = Story.objects.all()
+        serializer = StorySerializer(stories, many=True)
+        return JsonResponse(serializer.data, safe=False)
 
 
 def reader_story_evals(request, username):

--- a/stories/views.py
+++ b/stories/views.py
@@ -1,12 +1,33 @@
 from django.core.serializers import serialize
 from django.http import HttpResponse, JsonResponse
 from rest_framework.parsers import JSONParser
+from rest_framework import generics
+from rest_framework.permissions import AllowAny
+from rest_framework.authtoken.models import Token
+from rest_framework.response import Response
+from django.contrib.auth import authenticate
 from django.shortcuts import get_object_or_404
-
 from .models import Story
 from .models import StoryEval, Reader
-from .serializers import StorySerializer
+from .serializers import StorySerializer, UserSerializer
 from django.contrib.auth.models import User
+
+class RegisterView(generics.CreateAPIView):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [AllowAny]
+
+class LoginView(generics.GenericAPIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        username = request.data.get('username')
+        password = request.data.get('password')
+        user = authenticate(username=username, password=password)
+        if user is not None:
+            token, created = Token.objects.get_or_create(user=user)
+            return Response({'token': token.key})
+        return Response({'error': 'Invalid Credentials'}, status=400)
 
 def detail(request, id):
   story = Story.objects.get(id=id)

--- a/story_server/settings.py
+++ b/story_server/settings.py
@@ -149,5 +149,10 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly']
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
+    ],
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',
+    ],
 }

--- a/story_server/settings.py
+++ b/story_server/settings.py
@@ -49,7 +49,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    "stories"
+    'rest_framework',
+    'stories'
 ]
 
 MIDDLEWARE = [
@@ -143,3 +144,7 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly']
+}

--- a/story_server/settings.py
+++ b/story_server/settings.py
@@ -29,7 +29,9 @@ DEBUG = False
 
 ALLOWED_HOSTS = ["anthology.rcdis.co", "localhost", "127.0.0.1"]
 
-CSRF_TRUSTED_ORIGINS=['https://*.anthology.rcdis.co', 'https://*.127.0.0.1']
+CSRF_TRUSTED_ORIGINS=['https://*.anthology.rcdis.co', 'http://localhost:3000']
+CSRF_COOKIE_SAMESITE = 'None'
+CSRF_COOKIE_SECURE = True
 
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = [

--- a/story_server/settings.py
+++ b/story_server/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
     'stories'
 ]
 

--- a/story_server/settings.py
+++ b/story_server/settings.py
@@ -25,7 +25,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-58w9sr18di6jo=unusedsecretkey'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ["anthology.rcdis.co", "localhost", "127.0.0.1"]
 

--- a/story_server/settings.py
+++ b/story_server/settings.py
@@ -87,6 +87,7 @@ WSGI_APPLICATION = 'story_server.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 env = environ.Env()
+env.read_env(str(BASE_DIR) + '/.env')
 DATABASE_URL = env.str('DATABASE_URL')
 DATABASES = {
     'default': dj_database_url.config(default=DATABASE_URL),

--- a/story_server/urls.py
+++ b/story_server/urls.py
@@ -19,5 +19,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path("stories/", include("stories.urls")),
+    path('api/', include("stories.urls")),
 ]


### PR DESCRIPTION
Note: This PR introduces a breaking change. URLs within the stories app are now prefixed with "api/". This PR must be merged and deployed first for the [corresponding frontend PR](https://github.com/rama/anthology-app/pull/6) to function correctly.

- Added Django Rest Framework to the project to make it easier to create APIs.
- Migrated the `stories` endpoint to DRF.
- Implemented user registration, login and logout APIs.
- Decided to use token-based auth as our frontend and backend are decoupled.
- I also automated creation of a Reader object on user registration. I considered using signals for this, but decided against it for now to keep things simple.

Other quality-of-life improvements which are also part of this PR:
- We can now use a .env file to configure the local database URL.
- Set DEBUG to False.
- Some formatting adjustments.

Future Plans:
- Explore the implementation of a custom authentication class that can read the token from cookies instead of the Authorization header. This change would allow us to set the cookie as httpOnly, which is better for security.